### PR TITLE
Mark int overflow warnings as false positives for gosec

### DIFF
--- a/cmd/maximus/main.go
+++ b/cmd/maximus/main.go
@@ -7,5 +7,6 @@ import (
 )
 
 func main() {
-	fmt.Println(uint32(idmapper.Min(idmapper.MustGetMaxValidUID(), idmapper.MustGetMaxValidGID())))
+	// #nosec G115 - MustGetValidUID/GID would never return negative numbers, so this cast is safe after moving from uint32 to int
+	fmt.Println(uint(idmapper.Min(idmapper.MustGetMaxValidUID(), idmapper.MustGetMaxValidGID())))
 }

--- a/max_valid_uid.go
+++ b/max_valid_uid.go
@@ -38,6 +38,7 @@ func (u IDMap) MaxValid() (int, error) {
 		m = minUint(maxUint(m, container+size-1), uint(maxInt))
 	}
 
+	// #nosec G115 - maxInt is being used as an upper bound for the value of m, so it should never overflow when cast back to int
 	return int(m), nil
 }
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------



Backward Compatibility
---------------
Breaking Change? no