### PR TITLE
Update casting for a guardian g115 fix

### DIFF
--- a/idmapping.go
+++ b/idmapping.go
@@ -11,7 +11,7 @@ type MappingList []specs.LinuxIDMapping
 
 func (m MappingList) Map(id int) int {
 	for _, m := range m {
-		if delta := id - int(m.ContainerID); delta < int(m.Size) {
+		if delta := int(int64(id) - int64(m.ContainerID)); delta < int(m.Size) {
 			return int(m.HostID) + delta
 		}
 	}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This was originally made in the `vendor` directory of a guardian PR instead of to idmapper itself.

Backward Compatibility
---------------
Breaking Change? no